### PR TITLE
Fixed licence in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,7 @@
       "email": "pvsaintpe@umbrellio.biz"
     }
   ],
-  "license": [
-    "MIT License"
-  ],
+  "license": "MIT",
   "require": {
     "php": "^7.3|^7.4|^8.0",
     "laravel/framework": "^5.8|^6.0|^7.0|^8.0",


### PR DESCRIPTION
```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "MIT License" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```