### PR TITLE
Добавлена возможность построение дерева не с корневого элемента

### DIFF
--- a/src/Helpers/LTreeBuilder.php
+++ b/src/Helpers/LTreeBuilder.php
@@ -7,7 +7,6 @@ namespace Umbrellio\LTree\Helpers;
 use Umbrellio\LTree\Collections\LTreeCollection;
 use Umbrellio\LTree\Exceptions\LTreeReflectionException;
 use Umbrellio\LTree\Exceptions\LTreeUndefinedNodeException;
-use Umbrellio\LTree\Interfaces\LTreeModelInterface;
 
 class LTreeBuilder
 {
@@ -24,9 +23,6 @@ class LTreeBuilder
         $this->parentIdField = $parentIdField;
     }
 
-    /**
-     * @param LTreeCollection|LTreeModelInterface $items
-     */
     public function build(LTreeCollection $items, bool $usingSort = true): LTreeNode
     {
         if ($usingSort === true) {
@@ -41,7 +37,6 @@ class LTreeBuilder
             $this->nodes[$id] = $node;
         }
 
-        /** @var LTreeModelInterface $item */
         foreach ($items as $item) {
             [$id, $parentId, $path] = $this->getNodeIds($item);
             $node = $this->nodes[$id];
@@ -63,21 +58,6 @@ class LTreeBuilder
         return [$id, $parentId, $path];
     }
 
-    /**
-     * correct (missing: [1,2]) id  path        parent_id 1   1           null 2   1.2         1 3   1.2.3       2 4  
-     * 1.2.3.4     3 5   1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
-     *
-     * correct (missing: [1,2]) id  path        parent_id 3   1.2.3       2 4   1.2.3.4     3 5   1.2.3.4.5   4 6  
-     * 1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
-     *
-     *
-     *
-     * correct (missing: [1]) id  path        parent_id 2   1.2         1 3   1.2.3       2 4   1.2.3.4     3 5  
-     * 1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
-     *
-     * incorrect(missing: [2], but existing: [1]) id  path        parent_id 1   1           null 3   1.2.3       2 4  
-     * 1.2.3.4     3 5   1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
-     */
     private function getNode(int $id, string $path, ?int $parentId): LTreeNode
     {
         if ($parentId === null || $this->hasNoMissingNodes($id, $path)) {
@@ -100,8 +80,6 @@ class LTreeBuilder
                 $missingNodes++;
             }
         }
-
-//        dd(compact('id', 'path', 'missingNodes', 'subpathIds', 'subpath'));
 
         return $subpathIds > 0 && $missingNodes === count($subpathIds);
     }

--- a/src/Helpers/LTreeBuilder.php
+++ b/src/Helpers/LTreeBuilder.php
@@ -7,6 +7,7 @@ namespace Umbrellio\LTree\Helpers;
 use Umbrellio\LTree\Collections\LTreeCollection;
 use Umbrellio\LTree\Exceptions\LTreeReflectionException;
 use Umbrellio\LTree\Exceptions\LTreeUndefinedNodeException;
+use Umbrellio\LTree\Interfaces\LTreeModelInterface;
 
 class LTreeBuilder
 {
@@ -23,6 +24,9 @@ class LTreeBuilder
         $this->parentIdField = $parentIdField;
     }
 
+    /**
+     * @param LTreeCollection|LTreeModelInterface $items
+     */
     public function build(LTreeCollection $items, bool $usingSort = true): LTreeNode
     {
         if ($usingSort === true) {
@@ -37,10 +41,11 @@ class LTreeBuilder
             $this->nodes[$id] = $node;
         }
 
+        /** @var LTreeModelInterface $item */
         foreach ($items as $item) {
-            [$id, $parentId] = $this->getNodeIds($item);
+            [$id, $parentId, $path] = $this->getNodeIds($item);
             $node = $this->nodes[$id];
-            $parentNode = $this->getNode($parentId);
+            $parentNode = $this->getNode($id, $path, $parentId);
             $parentNode->addChild($node);
         }
         return $this->root;
@@ -50,21 +55,54 @@ class LTreeBuilder
     {
         $parentId = $item->{$this->parentIdField};
         $id = $item->{$this->idField};
+        $path = $item->{$this->pathField};
 
         if ($id === $parentId) {
             throw new LTreeReflectionException($id);
         }
-        return [$id, $parentId];
+        return [$id, $parentId, $path];
     }
 
-    private function getNode(?int $id): LTreeNode
+    /**
+     * correct (missing: [1,2]) id  path        parent_id 1   1           null 2   1.2         1 3   1.2.3       2 4  
+     * 1.2.3.4     3 5   1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
+     *
+     * correct (missing: [1,2]) id  path        parent_id 3   1.2.3       2 4   1.2.3.4     3 5   1.2.3.4.5   4 6  
+     * 1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
+     *
+     *
+     *
+     * correct (missing: [1]) id  path        parent_id 2   1.2         1 3   1.2.3       2 4   1.2.3.4     3 5  
+     * 1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
+     *
+     * incorrect(missing: [2], but existing: [1]) id  path        parent_id 1   1           null 3   1.2.3       2 4  
+     * 1.2.3.4     3 5   1.2.3.4.5   4 6   1.2.3.4.6   4 7   1.2.3.4.7   4 8   1.2.3.8     3 9   1.2.3.9     3
+     */
+    private function getNode(int $id, string $path, ?int $parentId): LTreeNode
     {
-        if ($id === null) {
+        if ($parentId === null || $this->hasNoMissingNodes($id, $path)) {
             return $this->root;
         }
-        if (!isset($this->nodes[$id])) {
-            throw new LTreeUndefinedNodeException($id);
+        if (!isset($this->nodes[$parentId])) {
+            throw new LTreeUndefinedNodeException($parentId);
         }
-        return $this->nodes[$id];
+        return $this->nodes[$parentId];
+    }
+
+    private function hasNoMissingNodes(int $id, string $path): bool
+    {
+        $subpath = substr($path, 0, -strlen(".{$id}"));
+        $subpathIds = explode('.', $subpath);
+
+        $missingNodes = 0;
+        foreach ($subpathIds as $parentId) {
+            if (!isset($this->nodes[$parentId])) {
+                $missingNodes++;
+            }
+        }
+
+//        dd(compact('id', 'path', 'missingNodes', 'subpathIds', 'subpath'));
+
+        return $subpathIds > 0 && $missingNodes === count($subpathIds);
     }
 }

--- a/tests.sh
+++ b/tests.sh
@@ -6,6 +6,6 @@ sed -e "s/\${USERNAME}/postgres/" \
     -e "s/\${DATABASE}/testing/" \
     -e "s/\${HOST}/127.0.0.1/" \
     phpunit.xml.dist > phpunit.xml
-composer update
+COMPOSER_MEMORY_LIMIT=-1 composer update
 composer lint
 php -d pcov.directory='.' vendor/bin/phpunit --coverage-html build --coverage-text

--- a/tests/_data/Traits/HasLTreeTables.php
+++ b/tests/_data/Traits/HasLTreeTables.php
@@ -35,7 +35,7 @@ trait HasLTreeTables
 
     protected function getCategoriesWithUnknownParent(): LTreeCollection
     {
-        CategoryStub::query()->find(11)->delete();
+        CategoryStub::query()->find(3)->delete();
         return $this->getCategories();
     }
 

--- a/tests/functional/Collections/LTreeCollectionTest.php
+++ b/tests/functional/Collections/LTreeCollectionTest.php
@@ -47,6 +47,27 @@ class LTreeCollectionTest extends LTreeBaseTestCase
         );
     }
 
+    /**
+     * @test
+     * @dataProvider providePartialConstencyTree
+     */
+    public function withoutLoadMissingForPartialTree(array $ids, array $expected): void
+    {
+        $this->assertSame(
+            CategoryStub::query()
+                ->whereKey($ids)
+                ->get()
+                ->toTree(true, false)
+                ->toCollection()
+                ->sortBy(function (LTreeModelInterface $item) {
+                    return $item->getKey();
+                })
+                ->pluck('id')
+                ->toArray(),
+            $expected
+        );
+    }
+
     public function provideTreeWithoutLeaves(): Generator
     {
         yield 'without_leaves' => [
@@ -80,8 +101,8 @@ class LTreeCollectionTest extends LTreeBaseTestCase
     public function provideNoConstency(): Generator
     {
         yield 'non_consistent_without_loading' => [
-            'ids' => [7, 3, 12],
-            'expected' => [3, 7, 12],
+            'ids' => [1, 6, 8],
+            'expected' => [1, 6, 8],
             'loadMissing' => false,
         ];
     }
@@ -117,6 +138,21 @@ class LTreeCollectionTest extends LTreeBaseTestCase
         yield 'consistent' => [
             'items' => [1, 3, 7],
             'expected' => [1, 3, 7],
+        ];
+    }
+    public function providePartialConstencyTree(): Generator
+    {
+        yield 'partial with single branch without single nodes' => [
+            'items' => [3, 6, 7, 8, 9, 10],
+            'expected' => [3, 6, 7, 8, 9, 10],
+        ];
+        yield 'partial with single branch without more nodes' => [
+            'items' => [6, 8, 9, 10],
+            'expected' => [6, 8, 9, 10],
+        ];
+        yield 'partial with more branches' => [
+            'items' => [6, 8, 9, 10, 11, 12],
+            'expected' => [6, 8, 9, 10, 11, 12],
         ];
     }
 }


### PR DESCRIPTION
При условии что в цепочке родителей нет пропусков, корректные кейсы

```
1.2.3
1.2.3.4
1.2.3.5
1.2.3.6
2
2.1
```
обе ветки не имеют пропусков


некорректный кейсы
```
1
1.2.3
1.2.3.4
1.2.3.5
1.2.3.6
```

т.к. между `1` и `1.2.3` есть пропуск узла `2`